### PR TITLE
Fixes for skewed timestamp and app directory bugs

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -42,6 +42,7 @@ fi
 
 
 echo "-----> compiling with make ..."
+touch *
 make | indent
 
 

--- a/bin/cppcms.sh
+++ b/bin/cppcms.sh
@@ -7,7 +7,7 @@ function indent() {
 }
 
 echo "-----> injecting environment into config.js ..."
-ls -R
+find . -name "cppcms.js"
 cp cppcms.js cppcms.js.template
 cat cppcms.js.template | \
   jq ".service.port=${PORT} | .service.ip=\"0.0.0.0\" | .service.api=\"http\"" | \

--- a/bin/cppcms.sh
+++ b/bin/cppcms.sh
@@ -7,7 +7,7 @@ function indent() {
 }
 
 echo "-----> injecting environment into config.js ..."
-ls -l
+ls -R
 cp cppcms.js cppcms.js.template
 cat cppcms.js.template | \
   jq ".service.port=${PORT} | .service.ip=\"0.0.0.0\" | .service.api=\"http\"" | \

--- a/bin/cppcms.sh
+++ b/bin/cppcms.sh
@@ -7,7 +7,12 @@ function indent() {
 }
 
 echo "-----> injecting environment into config.js ..."
-find . -name "cppcms.js"
+if ls cppcms.js ; then
+    echo "cppcms.js found in current directory"
+else
+    echo "Switching to app folder"
+    cd app
+fi
 cp cppcms.js cppcms.js.template
 cat cppcms.js.template | \
   jq ".service.port=${PORT} | .service.ip=\"0.0.0.0\" | .service.api=\"http\"" | \

--- a/bin/cppcms.sh
+++ b/bin/cppcms.sh
@@ -7,6 +7,7 @@ function indent() {
 }
 
 echo "-----> injecting environment into config.js ..."
+ls -l
 cp cppcms.js cppcms.js.template
 cat cppcms.js.template | \
   jq ".service.port=${PORT} | .service.ip=\"0.0.0.0\" | .service.api=\"http\"" | \


### PR DESCRIPTION
This fix deals with two problems I encountered while trying to use this buildpack:

1) There was a warning that the time of the files was ahead; solved with touch *
2) The directory that the json file was located as not the '.' but ./app; if the js file is not found in '.', cd to app

PS: Great job Mike! Thank you very much for your work!
